### PR TITLE
Require contribution on permissive terms

### DIFF
--- a/license.md
+++ b/license.md
@@ -90,8 +90,6 @@ Second, license parts of that software that haven't already been contributed in 
 
 2.  License on other terms with substantially the same legal effect as [Copyright](#copyright), [Patent](#patent), and [Reliability](#reliability).  Those other terms may, but need not, include a rule like [Notices](#notices), a disclaimer like [Disclaimer](#disclaimer), or both, but no other terms.
 
-3.  License on the terms of this license.
-
 <!-- Note that criterion 3 of the Open Source Definition requires permitting licensing on the same terms: https://writing.kemitchell.com/2018/11/05/OSD-Copyleft-Regulation.html#allow-the-same-terms-for-derived-works -->
 
 <!-- Note that BSD-2-Clause-Patent's patent grant follows Apache 2.0's approach to scope. -->


### PR DESCRIPTION
Criterion three of the Open Source Definition reads:

> The license must allow modifications and derived works, and
> must allow them to be distributed under the same terms as
> the license of the original software.

Since the license itself is open source, by definition, criterion
three allows work within the sweep of copyleft to be open source.
An open source copyleft license can't require "derived works" to be
closed, though it can allow it.  But as written, criterion three also
prevents open source copyleft licenses from requiring "derived works"
to be permissive open source.  If the license requires distributing
"derived works" under permissive terms , it thereby excludes
distributing under the same terms, which are copyleft terms.