### PR TITLE
Reformulate as a variant of Blue Oak 1.0.0

### DIFF
--- a/license.md
+++ b/license.md
@@ -88,9 +88,11 @@ Second, ensure that each part of that source code is licensed to the public unde
 
 1.  [The BSD-2-Clause Plus Patent License](https://spdx.org/licenses/BSD-2-Clause-Patent.html)
 
-2.  terms with substantially the same legal effect as [Copyright](#copyright), [Patent](#patent), and [Reliability](#reliability), and optionally a rule like [Notices](#notices), a disclaimer like [Disclaimer](#disclaimer), or both, but no other terms
+2.  [The Blue Oak Model License 1.0.0](https://spdx.org/licenses/BlueOak-1.0.0.html)
 
-3.  this license
+3.  terms with substantially the same legal effect as [Copyright](#copyright), [Patent](#patent), and [Reliability](#reliability), and optionally a rule like [Notices](#notices), a disclaimer like [Disclaimer](#disclaimer), or both, but no other terms
+
+4.  this license
 
 <!-- Note that criterion 3 of the Open Source Definition requires permitting licensing on the same terms: https://writing.kemitchell.com/2018/11/05/OSD-Copyleft-Regulation.html#allow-the-same-terms-for-derived-works -->
 

--- a/license.md
+++ b/license.md
@@ -1,13 +1,5 @@
 # API Copyleft License
 
-Developer: {Legal Name}
-
-<!-- The developer could be an individual, but more likely a legal entity. -->
-
-Homepage: {URL}
-
-<!-- Inspired by the "Source Code" notice line at the top of Parity.  Developers have been confused about what to put in the Source Code line.  Homepage and a URL placeholder should clear things up. -->
-
 ## Purpose
 
 <!-- See https://writing.kemitchell.com/2019/01/10/Discipline-Stated-Purpose.html -->
@@ -16,15 +8,9 @@ This license gives you permission to use, share, and build with this software fo
 
 <!-- Compare Parity, which does not make any permissive allowance for applications integrating the software being licensed: "This license lets you use and share this software for free, as long as you contribute software you make with it." -->
 
-## Disclaimer
-
-***As far as the law allows, this software comes as is, without any warranty, and the developer will not be liable to anyone for any damages related to this software or this license, for any kind of legal claim.***
-
-<!-- Plain text renderings of the license should use symbols, like asterisks, rather than ALL CAPS, for conspicuity. -->
-
 ## Acceptance
 
-In order to receive this license, you must agree to its rules.  Those rules are both obligations under our agreement and conditions to your license.  You may not do anything with this software that triggers a rule you cannot or will not follow.
+In order to receive this license, you must agree to its rules.  The rules of this license are both obligations under that agreement and conditions to your license.  You must not do anything with this software that triggers a rule that you cannot or will not follow.
 
 <!-- Because the license puts significant obligations on the licensee, we need to dispel confusion about legal characterization and remedies. To head off wasteful arguments in uncharted legal territory, expressly recite both contract and license.  The terms alone cannot establish contract. But in the likely event that facts do, clarify the consequences. -->
 
@@ -32,11 +18,17 @@ In order to receive this license, you must agree to its rules.  Those rules are 
 
 ## Copyright
 
-The developer licenses you to do everything with this software that would otherwise infringe copyrights in this software they can license.
+Each contributor licenses you to do everything with this software that would otherwise infringe that contributor's copyright in it.
+
+## Notices
+
+You must ensure that everyone who gets a copy of any part of this software from you, with or without changes, also gets the text of this license.
+
+<!-- TODO: Add URL for notices. -->
 
 ## Patent
 
-The developer licenses you to do everything with this software that would otherwise infringe any patent claims they can license.
+Each contributor licenses you to do everything with this software that would otherwise infringe any patent claims they can license or become able to license.
 
 <!-- Note the absence of any scope restriction, like Apache 2.0's limit to patents readings on the version to which someone contributed. First, that kind of scope language isn't particularly assuring.  It's often unclear how to tell what patents get covered, even with revision control data to hand.  Second, the primary use case for this license is entity licensors, who can do a single outbound patent analysis.  -->
 
@@ -44,15 +36,9 @@ The developer licenses you to do everything with this software that would otherw
 
 ## Reliability
 
-The developer will not revoke this license.
+No contributor can revoke this license.
 
 <!-- Express irrevocability.  Note that headings are _not_ disclaimed, and Reliance evokes the relevant legal concept. -->
-
-## Notices
-
-You must ensure that everyone who gets a copy of any part of this software from you, in source code or any other form, also gets the text of this license, including its developer and homepage lines.
-
-<!-- An orthodox open source style attribution condition. -->
 
 ## Copyleft
 
@@ -102,6 +88,11 @@ Take these steps within thirty calendar days of creating or using the software f
 
 ## Excuse
 
-You are excused for unknowingly breaking [Notices](#notices) or [Copyleft](#copyleft) if you do what the rule requires, or stop doing anything requiring this license, within thirty days of learning you broke the rule.
+If anyone notifies you in writing that you have not complied with [Notices](#notices) or [Copyleft](#copyleft), you can keep your license by taking all practical steps to comply within 30 days after the notice.  If you do not do so, your license ends immediately.
 
-<!-- This language permits multiple excuses, so long as the rule breaker doesn't know about their breach on account of factual circumstances, rather than ignorance of the license terms.  First notice of any violation will make a licensee aware of the license terms. -->
+## No Liability
+
+***As far as the law allows, this software comes as is, without any warranty or condition, and no contributor will be liable to anyone for any damages related to this software or this license, under any kind of legal claim.***
+
+<!-- Plain text renderings of the license should use symbols, like asterisks, rather than ALL CAPS, for conspicuity. -->
+


### PR DESCRIPTION
This PR could be seen in two ways:

1. backporting improvements from [Blue Oak 1.0.0](https://blueoakcouncil.org/license/1.0.0)

2. reformulating API Copyleft as a fork, or variant, of Blue Oak

The major elements of the delta:

1. now a fixed-form license, like Apache 2.0, rather than a template, like MIT or BSD

2. anticipates and speaks from all contributors

I need to think a bit more about the latter, and how it interacts with the copyleft licensing rule here. API Copyleft allows authors of work covered by copyleft to choose different licenses.