### PR TITLE
Clarify functionality pass-through for applications

### DIFF
--- a/license.md
+++ b/license.md
@@ -62,7 +62,7 @@ You need not contribute prototype changes, extensions, or applications that you 
 
 The purpose of this exception to [Copyleft](#copyleft) is to encourage cooperative development of this software, minimizing duplication of effort across competing substitutes.
 
-You need not contribute any application that only invokes this software's functionality through the interfaces this software exposes, without exposing this software's interfaces or functionality to other software to such an extent that it becomes a practical substitute for this software in other applications.
+You need not contribute any application that only invokes this software's functionality through the interfaces this software exposes, without exposing this software's interfaces or functionality to other software to such an extent that it becomes a practical substitute for this software.
 
 Interfaces exposed by this software include all the interfaces this software provides users or other software to invoke its functionality, such as command line, graphical, application programming, remote procedure call, and inter-process communication interfaces.
 

--- a/license.md
+++ b/license.md
@@ -62,7 +62,7 @@ You need not contribute prototype changes, extensions, or applications that you 
 
 The purpose of this exception to [Copyleft](#copyleft) is to encourage cooperative development of this software, minimizing duplication of effort across competing substitutes.
 
-You need not contribute any application that only invokes this software's functionality through the interfaces this software exposes, without exposing this software's interfaces or functionality to other software to such an extent that it becomes a practical substitute for this software.
+You need not contribute any application that only invokes this software's functionality through the interfaces this software exposes, without exposing this software's interfaces or functionality to users or other software to such an extent that it becomes a practical substitute for this software.
 
 Interfaces exposed by this software include all the interfaces this software provides users or other software to invoke its functionality, such as command line, graphical, application programming, remote procedure call, and inter-process communication interfaces.
 

--- a/license.md
+++ b/license.md
@@ -62,11 +62,9 @@ You need not contribute prototype changes, extensions, or applications that you 
 
 The purpose of this exception to [Copyleft](#copyleft) is to encourage cooperative development of this software, and to prohibit use of this software to create competing substitutes for this software that are not contributed.
 
-You need not contribute software that only invokes this software's functionality through the interfaces this software exposes, without exposing this software's interfaces or functionality to other software.
+You need not contribute software that only invokes this software's functionality through the interfaces this software exposes, without exposing this software's interfaces or functionality to other software.  Software that exposes this software's functionality only in specialized application to a particular use case does not count as exposing this software's functionality to other software.
 
 Interfaces exposed by this software include all the interfaces this software provides users or other software to invoke its functionality, such as command line, graphical, application programming, remote procedure call, and inter-process communication interfaces.
-
-Software that exposes this software's functionality only in specialized application to a particular use case does not count as exposing this software's functionality to other software.
 
 ## Contributing
 

--- a/license.md
+++ b/license.md
@@ -60,7 +60,7 @@ You need not contribute prototype changes, extensions, or applications that you 
 
 ## Applications
 
-The purpose of this exception to [Copyleft](#copyleft) is to encourage cooperative development of this software by prohibiting use of this software to create competing, proprietary substitutes.
+The purpose of this exception to [Copyleft](#copyleft) is to encourage cooperative development of this software, minimizing duplication of effort across competing substitutes.
 
 You need not contribute any application that only invokes this software's functionality through the interfaces this software exposes, without exposing this software's interfaces or functionality to other software to such an extent that it becomes a practical substitute for this software in other applications.
 

--- a/license.md
+++ b/license.md
@@ -60,7 +60,7 @@ You need not contribute prototype changes, extensions, or applications that you 
 
 ## Applications
 
-The purpose of this exception to [Copyleft](#copyleft) is to encourage cooperative development of this software, and to prohibit use of this software to create competing substitutes for this software that are not contributed.
+The purpose of this exception to [Copyleft](#copyleft) is to encourage cooperative development of this software by prohibiting use of this software to create competing, proprietary substitutes.
 
 You need not contribute software that only invokes this software's functionality through the interfaces this software exposes, without exposing this software's interfaces or functionality to other software.  Software that exposes this software's functionality only in specialized application to a particular use case does not count as exposing this software's functionality to other software.
 

--- a/license.md
+++ b/license.md
@@ -46,6 +46,8 @@ No contributor can revoke this license.
 
 ## Copyleft
 
+The purpose of this rule is to encourage cooperative development of this software, minimizing duplication of effort across competing substitutes.
+
 With two exceptions, [Prototypes](#prototypes) and [Applications](#applications), you must contribute all changes and additions to this software, as well as all software that invokes this software's functionality, according to [Contributing](#contributing).
 
 <!-- Compare MongoDB's statements on AGPLv3 https://www.mongodb.com/blog/post/the-agpl and SSPLv1 https://www.mongodb.com/licensing/server-side-public-license/faq#implications -->
@@ -60,7 +62,7 @@ You need not contribute prototype changes, extensions, or applications that you 
 
 ## Applications
 
-The purpose of this exception to [Copyleft](#copyleft) is to encourage cooperative development of this software, minimizing duplication of effort across competing substitutes.
+The purpose of this exception to [Copyleft](#copyleft) is to give you the freedom to share and license applications of this software as you like.
 
 You need not contribute any software that only invokes this software's functionality through the interfaces this software exposes, without exposing this software's interfaces or functionality to users or other software to such an extent that it becomes a practical substitute for this software.
 

--- a/license.md
+++ b/license.md
@@ -72,7 +72,7 @@ When this license requires you to contribute software:
 
 <!-- This language functions like a defined term, without falling back on lawyerly conventions that alienate non-lawyer readers. -->
 
-First, publish all source code for that software, in the preferred form for making changes, through a freely accessible distribution system widely used for similar source code, so the developer and others can find and copy it.
+First, publish all source code for that software, in the preferred form for making changes, through a freely accessible distribution system widely used for similar source code, so contributors and others can find and copy it.
 
 <!-- FSF has objected to licenses that require sending code back to the licensor specifically. -->
 

--- a/license.md
+++ b/license.md
@@ -62,7 +62,7 @@ You need not contribute prototype changes, extensions, or applications that you 
 
 The purpose of this exception to [Copyleft](#copyleft) is to encourage cooperative development of this software, and to prohibit use of this software to create competing substitutes for this software that are not contributed.
 
-You need not contribute software that only invokes this software's functionality through the interfaces this software exposes, without exposing this software's interfaces and functionality to other software.
+You need not contribute software that only invokes this software's functionality through the interfaces this software exposes, without exposing this software's interfaces or functionality to other software.
 
 Interfaces exposed by this software include all the interfaces this software provides users or other software to invoke its functionality, such as command line, graphical, application programming, remote procedure call, and inter-process communication interfaces.
 

--- a/license.md
+++ b/license.md
@@ -66,6 +66,8 @@ You need not contribute software that only invokes this software's functionality
 
 Interfaces exposed by this software include all the interfaces this software provides users or other software to invoke its functionality, such as command line, graphical, application programming, remote procedure call, and inter-process communication interfaces.
 
+Software that exposes this software's functionality only in specialized application to a particular use case does not count as exposing this software's functionality to other software.
+
 ## Contributing
 
 When this license requires you to contribute software:

--- a/license.md
+++ b/license.md
@@ -62,7 +62,7 @@ You need not contribute prototype changes, extensions, or applications that you 
 
 The purpose of this exception to [Copyleft](#copyleft) is to encourage cooperative development of this software by prohibiting use of this software to create competing, proprietary substitutes.
 
-You need not contribute software that only invokes this software's functionality through the interfaces this software exposes, without exposing this software's interfaces or functionality to other software.  Software that exposes this software's functionality only in specialized application to a particular use case does not count as exposing this software's functionality to other software.
+You need not contribute software that only invokes this software's functionality through the interfaces this software exposes, without exposing this software's interfaces or functionality to other software.  Exposing this software's functionality only in specialized application to a particular use case does not count as exposing this software's functionality.
 
 Interfaces exposed by this software include all the interfaces this software provides users or other software to invoke its functionality, such as command line, graphical, application programming, remote procedure call, and inter-process communication interfaces.
 

--- a/license.md
+++ b/license.md
@@ -62,7 +62,7 @@ You need not contribute prototype changes, extensions, or applications that you 
 
 The purpose of this exception to [Copyleft](#copyleft) is to encourage cooperative development of this software by prohibiting use of this software to create competing, proprietary substitutes.
 
-You need not contribute software that only invokes this software's functionality through the interfaces this software exposes, without exposing this software's interfaces or functionality to other software.  Exposing this software's functionality only in specialized application to a particular use case does not count as exposing this software's functionality.
+You need not contribute any application that only invokes this software's functionality through the interfaces this software exposes, without exposing this software's interfaces or functionality to other software to such an extent that it becomes a practical substitute for this software in other applications.
 
 Interfaces exposed by this software include all the interfaces this software provides users or other software to invoke its functionality, such as command line, graphical, application programming, remote procedure call, and inter-process communication interfaces.
 

--- a/license.md
+++ b/license.md
@@ -62,7 +62,7 @@ You need not contribute prototype changes, extensions, or applications that you 
 
 The purpose of this exception to [Copyleft](#copyleft) is to encourage cooperative development of this software, minimizing duplication of effort across competing substitutes.
 
-You need not contribute any application that only invokes this software's functionality through the interfaces this software exposes, without exposing this software's interfaces or functionality to users or other software to such an extent that it becomes a practical substitute for this software.
+You need not contribute any software that only invokes this software's functionality through the interfaces this software exposes, without exposing this software's interfaces or functionality to users or other software to such an extent that it becomes a practical substitute for this software.
 
 Interfaces exposed by this software include all the interfaces this software provides users or other software to invoke its functionality, such as command line, graphical, application programming, remote procedure call, and inter-process communication interfaces.
 

--- a/license.md
+++ b/license.md
@@ -48,7 +48,7 @@ No contributor can revoke this license.
 
 The purpose of this rule is to encourage cooperative development of this software, minimizing duplication of effort across competing substitutes.
 
-With two exceptions, [Prototypes](#prototypes) and [Applications](#applications), you must contribute all changes and additions to this software, as well as all software that invokes this software's functionality, according to [Contributing](#contributing).
+With two exceptions, [Prototypes](#prototypes) and [Applications](#applications), you must contribute all changes and additions to this software, as well as all software that invokes this software's functionality, according to [Contributing](#contributing).  When in doubt, contribute the software.
 
 <!-- Compare MongoDB's statements on AGPLv3 https://www.mongodb.com/blog/post/the-agpl and SSPLv1 https://www.mongodb.com/licensing/server-side-public-license/faq#implications -->
 


### PR DESCRIPTION
Responsive to #35 

This PR attempts to clarify the concept of exposing functionality to other software.

I shouldn't try to summarize in plain terms what I've already tried to write in the license. Have a look at the patch.