### PR TITLE
Backport improvements from Parity 7.0.0

### DIFF
--- a/license.md
+++ b/license.md
@@ -4,7 +4,7 @@ title: API Copyleft License
 
 # Purpose
 
-This license allows you to use, share, and build on this software for free, but you have to contribute changes, additions, and other software that you build with it, other than prototypes and applications.
+This license allows you to use and share this software for free.  You share and license your applications how you like.  But you have to share changes, additions, and other software that builds on this software alike.
 
 # Agreement
 

--- a/license.md
+++ b/license.md
@@ -6,7 +6,7 @@ title: API Copyleft License
 
 This license lets you use, share, and build on this software for free, but you have to contribute changes, additions, and other software that you build with it, other than prototypes and applications.
 
-# Acceptance
+# Agreement
 
 In order to receive this license, you must agree to its rules.  The rules of this license are both obligations under that agreement and conditions to your license.  You must not do anything with this software that triggers a rule that you cannot or will not follow.
 

--- a/license.md
+++ b/license.md
@@ -20,7 +20,11 @@ With two exceptions, [Prototypes](#prototypes) and [Applications](#applications)
 
 # Prototypes
 
-You need not contribute prototype changes, extensions, or other software that you do not end up using for more than fourteen calendar days, sharing with anyone else, or using to provide a service to anyone else.  The purpose of this exception to [Copyleft](#copyleft) is to allow you to experiment in private.
+You don't have to contribute any change, addition, or other software that meets all these criteria:
+
+1.  You don't use it for more than thirty days.
+
+2.  You don't share it outside the team developing it, other than for non-production user testing.
 
 # Applications
 

--- a/license.md
+++ b/license.md
@@ -8,7 +8,7 @@ This license lets you use, share, and build on this software for free, but you h
 
 # Agreement
 
-In order to receive this license, you must agree to its rules.  The rules of this license are both obligations under that agreement and conditions to your license.  You must not do anything with this software that triggers a rule that you cannot or will not follow.
+In order to receive this license, you have to agree to its rules.  Those rules are both obligations under that agreement and conditions to your license.  Don't do anything with this software that triggers a rule you can't or won't follow.
 
 # Copyright
 

--- a/license.md
+++ b/license.md
@@ -30,7 +30,7 @@ You don't have to contribute any change, addition, or other software that meets 
 
 # Applications
 
-You don't have to contribute any software that only invokes this software's functionality through the interfaces this software exposes, without exposing this software's interfaces or functionality to users, programmers, or other software to such an extent that it becomes a practical substitute for this software.  Interfaces exposed by this software include all the interfaces this software provides users, programmers, or other software to invoke its functionality, such as command line, graphical, application programming, remote procedure call, and inter-process communication interfaces.
+You don't have to contribute any software that only invokes this software's functionality through the interfaces this software exposes, unless it exposes so much of this software's interfaces or functionality to users, programmers, or other software that it becomes a practical substitute for this software.  Interfaces exposed by this software include all the interfaces this software provides users, programmers, or other software to invoke its functionality, such as command line, graphical, application programming, remote procedure call, and inter-process communication interfaces.
 
 # Contribute
 

--- a/license.md
+++ b/license.md
@@ -26,6 +26,8 @@ You don't have to contribute any change, addition, or other software that meets 
 
 2.  You don't share it outside the team developing it, other than for non-production user testing.
 
+3.  You don't use it for anyone outside the team developing it.
+
 # Applications
 
 You don't have to contribute any software that only invokes this software's functionality through the interfaces this software exposes, without exposing this software's interfaces or functionality to users, programmers, or other software to such an extent that it becomes a practical substitute for this software.  Interfaces exposed by this software include all the interfaces this software provides users, programmers, or other software to invoke its functionality, such as command line, graphical, application programming, remote procedure call, and inter-process communication interfaces.  The purpose of this exception to [Copyleft](#copyleft) is to allow you to share and license applications of this software as you choose.

--- a/license.md
+++ b/license.md
@@ -16,7 +16,7 @@ Make sure everyone who gets a copy of any part of this software from you, with o
 
 # Copyleft
 
-With two exceptions, [Prototypes](#prototypes) and [Applications](#applications), contribute all changes and additions to this software, as well as all software that invokes this software's functionality.  When in doubt, contribute.
+With two exceptions, [Prototypes](#prototypes) and [Applications](#applications), contribute all changes and additions that you make to this software, as well as all software that invokes this software's functionality.  When in doubt, contribute.
 
 # Prototypes
 

--- a/license.md
+++ b/license.md
@@ -16,7 +16,7 @@ Make sure everyone who gets a copy of any part of this software from you, with o
 
 # Copyleft
 
-With two exceptions, [Prototypes](#prototypes) and [Applications](#applications), contribute all changes and additions to this software, as well as all software that invokes this software's functionality.  The purpose of this rule is to encourage cooperative development of this software, minimizing duplication of effort across competing substitutes.  When in doubt, contribute the software.
+With two exceptions, [Prototypes](#prototypes) and [Applications](#applications), contribute all changes and additions to this software, as well as all software that invokes this software's functionality.  When in doubt, contribute.
 
 # Prototypes
 

--- a/license.md
+++ b/license.md
@@ -16,7 +16,7 @@ Make sure everyone who gets a copy of any part of this software from you, with o
 
 # Copyleft
 
-With two exceptions, [Prototypes](#prototypes) and [Applications](#applications), contribute all changes and additions that you make to this software, as well as all software that invokes this software's functionality.  When in doubt, contribute.
+With two exceptions, [Prototypes](#prototypes) and [Applications](#applications), contribute all changes and additions you make to this software, as well as all software that invokes this software's functionality.  When in doubt, contribute.
 
 # Prototypes
 

--- a/license.md
+++ b/license.md
@@ -12,7 +12,7 @@ In order to receive this license, you have to agree to its rules.  Those rules a
 
 # Notices
 
-You must ensure that everyone who gets a copy of any part of this software from you, with or without changes, also gets the text of this license or a link to https://apicopyleft.com/license/{version}.
+Make sure everyone who gets a copy of any part of this software from you, with or without changes, also gets the text of this license of a link to https://apicopyleft.com/license/{version}.
 
 # Copyright
 

--- a/license.md
+++ b/license.md
@@ -4,7 +4,7 @@ title: API Copyleft License
 
 # Purpose
 
-This license gives you permission to use, share, and build with this software for free, but requires you to contribute source code for changes, additions, and other software that you build with it, other than prototypes and applications.
+This license lets you use, share, and build on this software for free, but you have to contribute changes, additions, and other software that you build with it, other than prototypes and applications.
 
 # Acceptance
 

--- a/license.md
+++ b/license.md
@@ -4,7 +4,7 @@ title: API Copyleft License
 
 # Purpose
 
-This license allows you to use and share this software for free.  You share and license your applications how you like.  But you have to share changes, additions, and other software that builds on this software alike.
+This license allows you to use and share this software for free.  You share and license your applications how you like, but you have to share changes, additions, and other software that builds on this software alike.
 
 # Agreement
 

--- a/license.md
+++ b/license.md
@@ -4,7 +4,7 @@ title: API Copyleft License
 
 # Purpose
 
-This license lets you use, share, and build on this software for free, but you have to contribute changes, additions, and other software that you build with it, other than prototypes and applications.
+This license allows you to use, share, and build on this software for free, but you have to contribute changes, additions, and other software that you build with it, other than prototypes and applications.
 
 # Agreement
 

--- a/license.md
+++ b/license.md
@@ -12,7 +12,7 @@ In order to receive this license, you have to agree to its rules.  Those rules a
 
 # Notices
 
-Make sure everyone who gets a copy of any part of this software from you, with or without changes, also gets the text of this license of a link to https://apicopyleft.com/license/{version}.
+Make sure everyone who gets a copy of any part of this software from you, with or without changes, also gets the text of this license or a link to https://apicopyleft.com/license/{version}.
 
 # Copyleft
 

--- a/license.md
+++ b/license.md
@@ -30,7 +30,7 @@ You don't have to contribute any change, addition, or other software that meets 
 
 # Applications
 
-You don't have to contribute any software that only invokes this software's functionality through the interfaces this software exposes, without exposing this software's interfaces or functionality to users, programmers, or other software to such an extent that it becomes a practical substitute for this software.  Interfaces exposed by this software include all the interfaces this software provides users, programmers, or other software to invoke its functionality, such as command line, graphical, application programming, remote procedure call, and inter-process communication interfaces.  The purpose of this exception to [Copyleft](#copyleft) is to allow you to share and license applications of this software as you choose.
+You don't have to contribute any software that only invokes this software's functionality through the interfaces this software exposes, without exposing this software's interfaces or functionality to users, programmers, or other software to such an extent that it becomes a practical substitute for this software.  Interfaces exposed by this software include all the interfaces this software provides users, programmers, or other software to invoke its functionality, such as command line, graphical, application programming, remote procedure call, and inter-process communication interfaces.
 
 # Contribute
 

--- a/license.md
+++ b/license.md
@@ -4,7 +4,7 @@ title: API Copyleft License
 
 # Purpose
 
-This license allows you to use and share this software for free.  You share and license your applications how you like, but you have to share changes, additions, and other software that builds on this software alike.
+This license allows you to use and share this software for free.  You can share and license your applications how you like, but you have to share changes, additions, and other software that builds on this software alike.
 
 # Agreement
 

--- a/license.md
+++ b/license.md
@@ -16,7 +16,7 @@ Make sure everyone who gets a copy of any part of this software from you, with o
 
 # Copyleft
 
-With two exceptions, [Prototypes](#prototypes) and [Applications](#applications), you must contribute all changes and additions to this software, as well as all software that invokes this software's functionality, according to [Contributing](#contributing).  The purpose of this rule is to encourage cooperative development of this software, minimizing duplication of effort across competing substitutes.  When in doubt, contribute the software.
+With two exceptions, [Prototypes](#prototypes) and [Applications](#applications), contribute all changes and additions to this software, as well as all software that invokes this software's functionality.  The purpose of this rule is to encourage cooperative development of this software, minimizing duplication of effort across competing substitutes.  When in doubt, contribute the software.
 
 # Prototypes
 
@@ -28,27 +28,19 @@ You don't have to contribute any change, addition, or other software that meets 
 
 # Applications
 
-You need not contribute any software that only invokes this software's functionality through the interfaces this software exposes, without exposing this software's interfaces or functionality to users, programmers, or other software to such an extent that it becomes a practical substitute for this software.  Interfaces exposed by this software include all the interfaces this software provides users, programmers, or other software to invoke its functionality, such as command line, graphical, application programming, remote procedure call, and inter-process communication interfaces.  The purpose of this exception to [Copyleft](#copyleft) is to allow you to share and license applications of this software as you choose.
+You don't have to contribute any software that only invokes this software's functionality through the interfaces this software exposes, without exposing this software's interfaces or functionality to users, programmers, or other software to such an extent that it becomes a practical substitute for this software.  Interfaces exposed by this software include all the interfaces this software provides users, programmers, or other software to invoke its functionality, such as command line, graphical, application programming, remote procedure call, and inter-process communication interfaces.  The purpose of this exception to [Copyleft](#copyleft) is to allow you to share and license applications of this software as you choose.
 
-# Contributing
+# Contribute
 
-When this license requires you to contribute software, take these steps within thirty calendar days of creating or using the software for the first time:
+To [contribute](#contribute) software:
 
-1.  Publish all source code for the software, in the preferred form for making changes, through a freely accessible distribution system widely used for similar source code, so contributors and others can find and copy it.
+1.  Publish all source code for the software in the preferred form for making changes through a freely accessible distribution system widely used for similar source code so the contributor and others can find and copy it.
 
-2.  Ensure that each part of the source code is licensed to the public under one or more of these:
+2.  Make sure every part of the source code is available under this license, the Blue Oak Model License 1.0.0, the BSD-2-Clause Plus Patent License, or terms with substantially the same legal effect as [Copyright](#copyright), [Patent](#patent), and [Reliability](#reliability), and optionally a rule like [Notices](#notices), a disclaimer like [No Liability](#no-liability), or both, but no other terms.
 
-    - The Blue Oak Model License 1.0.0
+3.  Take these steps within thirty days.
 
-    - The BSD-2-Clause Plus Patent License
-
-    - terms with substantially the same legal effect as [Copyright](#copyright), [Patent](#patent), and [Reliability](#reliability), and optionally a rule like [Notices](#notices), a disclaimer like [No Liability](#no-liability), or both, but no other terms
-
-    - this license
-
-# No Relicensing
-
-[Contributing](#contributing) does not allow you to change the license terms for this software.  [Contributing](#contributing) only allows you to choose terms for other software covered by [Copyleft](#copyleft).
+4.  Note that this license does not allow you to change the license terms for this software.  You must follow [Notices](#notices).
 
 # Excuse
 

--- a/license.md
+++ b/license.md
@@ -34,7 +34,7 @@ You don't have to contribute any software that only invokes this software's func
 
 # Contribute
 
-To [contribute](#contribute) software:
+To contribute software:
 
 1.  Publish all source code for the software in the preferred form for making changes through a freely accessible distribution system widely used for similar source code so the contributor and others can find and copy it.
 

--- a/license.md
+++ b/license.md
@@ -44,7 +44,7 @@ To [contribute](#contribute) software:
 
 # Excuse
 
-If anyone notifies you in writing that you have not complied with [Notices](#notices), you can keep your license by taking all practical steps to comply within thirty calendar days after the notice.  If anyone notifies you in writing that you have not complied with [Copyleft](#copyleft), you can keep your license by taking all steps to comply, and responding with the address for the software in the distribution system through which you published, within thirty calendar days after the notice.  If you do not take these steps to comply after a notice, your license ends immediately.
+You're excused for unknowingly breaking [Copyleft](#copyleft) if you contribute as required, or stop doing anything requiring this license, within thirty days of learning you broke the rule.  You're excused for unknowingly breaking [Notices](#notices) if you take all practical steps to comply within thirty days of learning you broke the rule.
 
 # Copyright
 

--- a/license.md
+++ b/license.md
@@ -14,18 +14,6 @@ In order to receive this license, you have to agree to its rules.  Those rules a
 
 Make sure everyone who gets a copy of any part of this software from you, with or without changes, also gets the text of this license of a link to https://apicopyleft.com/license/{version}.
 
-# Copyright
-
-Each contributor licenses you to do everything with this software that would otherwise infringe that contributor's copyright in it.
-
-# Patent
-
-Each contributor licenses you to do everything with this software that would otherwise infringe any patent claims they can license or become able to license.
-
-# Reliability
-
-No contributor can revoke this license.
-
 # Copyleft
 
 With two exceptions, [Prototypes](#prototypes) and [Applications](#applications), you must contribute all changes and additions to this software, as well as all software that invokes this software's functionality, according to [Contributing](#contributing).  The purpose of this rule is to encourage cooperative development of this software, minimizing duplication of effort across competing substitutes.  When in doubt, contribute the software.
@@ -61,6 +49,18 @@ When this license requires you to contribute software, take these steps within t
 # Excuse
 
 If anyone notifies you in writing that you have not complied with [Notices](#notices), you can keep your license by taking all practical steps to comply within thirty calendar days after the notice.  If anyone notifies you in writing that you have not complied with [Copyleft](#copyleft), you can keep your license by taking all steps to comply, and responding with the address for the software in the distribution system through which you published, within thirty calendar days after the notice.  If you do not take these steps to comply after a notice, your license ends immediately.
+
+# Copyright
+
+Each contributor licenses you to do everything with this software that would otherwise infringe that contributor's copyright in it.
+
+# Patent
+
+Each contributor licenses you to do everything with this software that would otherwise infringe any patent claims they can license or become able to license.
+
+# Reliability
+
+No contributor can revoke this license.
 
 # No Liability
 

--- a/license.md
+++ b/license.md
@@ -10,13 +10,13 @@ This license lets you use, share, and build on this software for free, but you h
 
 In order to receive this license, you have to agree to its rules.  Those rules are both obligations under that agreement and conditions to your license.  Don't do anything with this software that triggers a rule you can't or won't follow.
 
-# Copyright
-
-Each contributor licenses you to do everything with this software that would otherwise infringe that contributor's copyright in it.
-
 # Notices
 
 You must ensure that everyone who gets a copy of any part of this software from you, with or without changes, also gets the text of this license or a link to https://apicopyleft.com/license/{version}.
+
+# Copyright
+
+Each contributor licenses you to do everything with this software that would otherwise infringe that contributor's copyright in it.
 
 # Patent
 


### PR DESCRIPTION
This PR began with "backporting" with bringing improvements to the [prototypes](https://paritylicense.com/versions/7.0.0.html#prototypes) section of Parity 7.0.0 to API Copyleft. It soon grew out into a full refresh of API Copyleft, leveraging all the stylistic and other goodies in Parity. I've also brought over a version of the automated release script from the Parity repo.

The diff is busy enough that it's probably worth focusing on the edited file only. Fortunately, things have only gotten shorter and easier to read.