### PR TITLE
Applications: Add "programmers" to "users" and "software" (close #43)

### DIFF
--- a/license.md
+++ b/license.md
@@ -30,9 +30,9 @@ This rule requires cooperative development of this software, minimizing duplicat
 
 ## Applications
 
-You don't have to contribute any software that only invokes this software's functionality through the interfaces this software exposes, unless that software exposes so much of this software's interfaces or functionality to users or other software that it becomes a practical substitute for this software.
+You don't have to contribute any software that only invokes this software's functionality through the interfaces this software exposes, unless that software exposes so much of this software's interfaces or functionality to users, programmers, or other software that it becomes a practical substitute for this software.
 
-Interfaces exposed by this software include all the interfaces this software provides users or other software to invoke its functionality, such as command line, graphical, application programming, remote procedure call, and inter-process communication interfaces.
+Interfaces exposed by this software include all the interfaces this software provides users, programmers, or other software to invoke its functionality, such as command line, graphical, application programming, remote procedure call, and inter-process communication interfaces.
 
 This exception to [Copyleft](#copyleft) allows building, sharing, and licensing applications as you like.
 


### PR DESCRIPTION
@simerplaha, here's a proposal that I think I might address your concerns in #43 _without_ having to add a bunch of specific notices about "classes", "traits", "mixins", and other means of abstraction.